### PR TITLE
Fix Vercel compilation error - remove unused import

### DIFF
--- a/web/app/civics/page.tsx
+++ b/web/app/civics/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import { lookupAddress } from '@/lib/civics/sources/civicinfo/index';
 
 interface District {
   id: string;


### PR DESCRIPTION
## 🐛 **Fix Vercel Compilation Error**

### **Problem:**
Vercel deployment was failing with:
find is /usr/bin/find
type is a shell builtin

### **Solution:**
- Removed unused  import from 
- The import was causing module resolution issues during build

### **Testing:**
- ✅ Local build passes successfully
- ✅ All TypeScript compilation errors resolved
- ✅ No functional changes to the civics page

### **Impact:**
- Fixes Vercel deployment failures
- Maintains all existing functionality
- Clean, minimal fix with no side effects